### PR TITLE
Allow empty start and end time in case of set_worktime

### DIFF
--- a/bin/hack-spirit
+++ b/bin/hack-spirit
@@ -154,12 +154,12 @@ program
   .command('set_worktime')
   .description('Set work time')
   .option(`-d, --date [${dateFormat}]`, 'When you want to set work time (default: today)')
-  .option(`-s, --start [${timeFormat}]`, 'start time (default: 1000)')
-  .option(`-e, --end [${timeFormat}]`, 'end time (default: 1900')
+  .option(`-s, --start [${timeFormat}]`, 'start time')
+  .option(`-e, --end [${timeFormat}]`, 'end time')
   .action((opts) => {
       let date = opts.date ? moment(opts.date, datetimeFormat).toDate() : new Date();
-      let start = opts.start ? moment(opts.start, 'HHmm') : moment('1000', 'HHmm');
-      let end = opts.end ? moment(opts.end, 'HHmm') : moment('1900', 'HHmm');
+      let start = opts.start ? moment(opts.start, 'HHmm') : null;
+      let end = opts.end ? moment(opts.end, 'HHmm') : null;
       let HackSpirit = require('../lib/hack-spirit');
       let hackSpirit = new HackSpirit(program.browser, program.verbose);
       hackSpirit.setWorkTime(program.user, program.password, date, start, end);

--- a/lib/hack-spirit.js
+++ b/lib/hack-spirit.js
@@ -271,7 +271,7 @@ class HackSpirit {
 
       yield ts.login(userName, password);
       yield self.teamSpiritClient.setWorkTime(date, start, end);
-      self.print('Succeeded in set work time ' + `${moment(date).format('YYYY-MM-DD')} ${start.format('HH:mm')}-${end.format('HH:mm')}`);
+      self.print('Succeeded in set work time ' + `${moment(date).format('YYYY-MM-DD')} ${start ? start.format('HH:mm') : '*'}-${end ? end.format('HH:mm') : '*'}`);
       return Promise.resolve(ExitStatus.Success);
     }).then(self.onSuccess, self.onError);
   }

--- a/lib/team-spirit.js
+++ b/lib/team-spirit.js
@@ -395,13 +395,22 @@ class TeamSpirit {
     let endBox = '#endTime';
     
     yield this.showWorkTimeOfDayDialog(date).then(() => {
+        this.nightmare
+            .wait(startBox)
+            .wait(1000)
+    }).then(() => {
+        if (start) {
+            this.nightmare
+                .insert(startBox)
+                .insert(startBox, start.format('HH:mm'))
+        }
+        if (end) {
+            this.nightmare
+                .insert(endBox)
+                .insert(endBox, end.format('HH:mm'))
+        }
+    }).then(() => {
       return this.nightmare
-        .wait(startBox)
-        .wait(1000)
-        .insert(startBox)
-        .insert(startBox, start.format('HH:mm'))
-        .insert(endBox)
-        .insert(endBox, end.format('HH:mm'))
         .wait(okButton)
         .click(okButton)
         .evaluate(() => {


### PR DESCRIPTION
I want to set only start/end time when I execute `set_worktime`.
So the changes in this PR allow empty start/end time in case of `set_worktime`.

e.g.

```console
$ ./bin/hack-spirit set_worktime -d 20170705 -s 1000 -e 1930
Succeeded in set work time 2017-07-05 10:00-19:30

$ ./bin/hack-spirit set_worktime -d 20170705 -e 1700
Succeeded in set work time 2017-07-05 *-17:00
# It means 10:00-17:00. The start time isn't updated.

$ ./bin/hack-spirit set_worktime -d 20170705 -s 1100
Succeeded in set work time 2017-07-05 11:00-*
# It means 11:00-17:00. The end time isn't updated.
```
